### PR TITLE
Update livewire datatable class

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,7 @@
     "require": {
         "php": "^8.0",
         "illuminate/support": "^7.0|^8.0|^9.0|^10.0",
-        "livewire/livewire": "^2.4.4",
+        "livewire/livewire": "^3.0",
         "maatwebsite/excel": "^3.1",
         "reedware/laravel-relation-joins": "^2.4|^3.0|^4.0"
     },

--- a/resources/views/livewire/datatables/checkbox.blade.php
+++ b/resources/views/livewire/datatables/checkbox.blade.php
@@ -1,7 +1,7 @@
 <div class="flex justify-center">
     <input
         type="checkbox"
-        wire:model="selected"
+        wire:model.live="selected"
         value="{{ $value }}"
         @if (property_exists($this, 'pinnedRecords') && in_array($value, $this->pinnedRecords)) checked @endif
         class="w-4 h-4 mt-1 text-blue-600 form-checkbox transition duration-150 ease-in-out"

--- a/resources/views/livewire/datatables/complex-query-group.blade.php
+++ b/resources/views/livewire/datatables/complex-query-group.blade.php
@@ -4,8 +4,7 @@
         <div wire:key="{{ $key }}">
             @if($rule['type'] === 'rule')
                 @include('datatables::complex-query-rule', ['parentIndex' => $key, 'rule' => $rule])
-            @elseif($rule['type'] === 'group')
-                <div x-data="{
+            @elseif($rule['type'] === 'group')<div x-data="{
                     key: '{{ collect(explode('.', $key))->join(".content.") . ".content" }}',
                     source: () => document.querySelector('[dragging]'),
                     dragstart: (e, key) => {
@@ -42,7 +41,7 @@
                                 <div class="mr-8">
                                     <label class="block uppercase tracking-wide text-xs font-bold py-1 rounded flex justify-between">Logic</label>
                                     <select
-                                        wire:model="rules.{{ collect(explode('.', $key))->join(".content.") }}.logic"
+                                        wire:model.live="rules.{{ collect(explode('.', $key))->join(".content.") }}.logic"
                                         class="w-24 text-sm leading-4 block rounded-md border-gray-300 shadow-sm focus:border-blue-300 focus:ring focus:ring-blue-200 focus:ring-opacity-50"
                                     >
                                         <option value="and">AND</option>

--- a/resources/views/livewire/datatables/complex-query-rule.blade.php
+++ b/resources/views/livewire/datatables/complex-query-rule.blade.php
@@ -12,7 +12,7 @@
                 <label
                     class="block uppercase tracking-wide text-xs font-bold py-1 rounded flex justify-between">Column</label>
                 <div class="relative">
-                    <select wire:model="rules.{{ $key }}.column" name="selectedColumn"
+                    <select wire:model.live="rules.{{ $key }}.column" name="selectedColumn"
                         class="w-full my-1 text-sm text-gray-900 leading-4 block rounded-md border-gray-300 shadow-sm focus:border-blue-300 focus:ring focus:ring-blue-200 focus:ring-opacity-50">
                         <option value=""></option>
                         @foreach ($columns as $i => $column)
@@ -27,7 +27,7 @@
                     <label
                         class="block uppercase tracking-wide text-xs font-bold py-1 rounded flex justify-between">Operand</label>
                     <div class="relative">
-                        <select name="operand" wire:model="rules.{{ $key }}.operand"
+                        <select name="operand" wire:model.live="rules.{{ $key }}.operand"
                             class="w-full my-1 text-sm text-gray-900 leading-4 block rounded-md border-gray-300 shadow-sm focus:border-blue-300 focus:ring focus:ring-blue-200 focus:ring-opacity-50">
                             <option selected></option>
                             @foreach ($options as $operand)
@@ -45,7 +45,7 @@
                             class="block uppercase tracking-wide text-xs font-bold py-1 rounded flex justify-between">Value</label>
                         <div class="relative">
                             @if (is_array($column['filterable']))
-                                <select name="value" wire:model="rules.{{ $key }}.value"
+                                <select name="value" wire:model.live="rules.{{ $key }}.value"
                                     class="w-full my-1 text-sm text-gray-900 leading-4 block rounded-md border-gray-300 shadow-sm focus:border-blue-300 focus:ring focus:ring-blue-200 focus:ring-opacity-50">
                                     <option selected></option>
                                     @foreach ($column['filterable'] as $value => $label)
@@ -61,7 +61,7 @@
                                     @endforeach
                                 </select>
                             @elseif($column['type'] === 'boolean')
-                                <select name="value" wire:model="rules.{{ $key }}.value"
+                                <select name="value" wire:model.live="rules.{{ $key }}.value"
                                     class="w-full my-1 text-sm text-gray-900 leading-4 block rounded-md border-gray-300 shadow-sm focus:border-blue-300 focus:ring focus:ring-blue-200 focus:ring-opacity-50">
                                     <option selected></option>
                                     <option value="true">True</option>

--- a/resources/views/livewire/datatables/datatable.blade.php
+++ b/resources/views/livewire/datatables/datatable.blade.php
@@ -1,129 +1,167 @@
-<div>
-    @includeIf($beforeTableSlot)
-    <div class="relative">
-        <div class="flex items-center justify-between mb-1">
-            @if(isset($this->multisort) && $this->multisort === true && count($this->sort) > 1)
-                <button wire:loading.class="opacity-50" wire:click="forgetSortSession"
-                        class="px-3 py-2 border border-blue-400 rounded-md bg-white text-blue-500 text-xs leading-4 font-medium uppercase tracking-wider hover:bg-blue-200 focus:outline-none">
-                    <div class="flex items-center h-2">
-                        {{ __('Reset Columns Sort')}}
-                    </div>
-                </button>
-            @endif
-            <div class="flex items-center h-10">
-                @if($this->searchableColumns()->count())
-                    <div class="flex rounded-lg w-96 shadow-sm">
-                        <div class="relative flex-grow focus-within:z-10">
-                            <div class="absolute inset-y-0 left-0 flex items-center pl-3 pointer-events-none">
-                                <svg class="w-5 h-5 text-gray-400" viewBox="0 0 20 20" stroke="currentColor" fill="none">
-                                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M21 21l-6-6m2-5a7 7 0 11-14 0 7 7 0 0114 0z" />
-                                </svg>
-                            </div>
-                            <input wire:model.debounce.500ms="search" class="block w-full py-3 pl-10 text-sm border-gray-300 leading-4 rounded-md shadow-sm focus:border-blue-300 focus:ring focus:ring-blue-200 focus:ring-opacity-50 focus:outline-none" placeholder="{{__('Search in')}} {{ $this->searchableColumns()->map->label->join(', ') }}" type="text" />
-                            <div class="absolute inset-y-0 right-0 flex items-center pr-2">
-                                <button wire:click="$set('search', null)" class="text-gray-300 hover:text-red-600 focus:outline-none">
-                                    <x-icons.x-circle class="w-5 h-5 stroke-current" />
-                                </button>
-                            </div>
-                        </div>
-                    </div>
-                @endif
-            </div>
-
-            @if($this->activeFilters)
-                <span class="text-xl text-blue-400 uppercase">@lang('Filter active')</span>
-            @endif
-
-            <div class="flex flex-wrap items-center space-x-1">
-                <x-icons.cog wire:loading class="text-gray-400 h-9 w-9 animate-spin" />
-
-                @if($this->activeFilters)
-                    <button wire:click="clearAllFilters" class="flex items-center px-3 text-xs font-medium tracking-wider text-red-500 uppercase bg-white border border-red-400 space-x-2 rounded-md leading-4 hover:bg-red-200 focus:outline-none"><span>{{ __('Reset') }}</span>
-                        <x-icons.x-circle class="m-2" />
-                    </button>
-                @endif
-
-                @if(count($this->massActionsOptions))
-                    <div class="flex items-center justify-center space-x-1">
-                        <label for="datatables_mass_actions">{{ __('With selected') }}:</label>
-                        <select wire:model.live="massActionOption" class="px-3 text-xs font-medium tracking-wider uppercase bg-white border border-green-400 space-x-2 rounded-md leading-4 focus:outline-none" id="datatables_mass_actions">
-                            <option value="">{{ __('Choose...') }}</option>
-                            @foreach($this->massActionsOptions as $group => $items)
-                                @if(!$group)
-                                    @foreach($items as $item)
-                                        <option value="{{$item['value']}}">{{$item['label']}}</option>
-                                    @endforeach
-                                @else
-                                    <optgroup label="{{$group}}">
-                                        @foreach($items as $item)
-                                            <option value="{{$item['value']}}">{{$item['label']}}</option>
-                                        @endforeach
-                                    </optgroup>
-                                @endif
-                            @endforeach
-                        </select>
-                        <button
-                            wire:click="massActionOptionHandler"
-                            class="flex items-center px-4 py-2 text-xs font-medium tracking-wider text-green-500 uppercase bg-white border border-green-400 rounded-md leading-4 hover:bg-green-200 focus:outline-none" type="submit" title="Submit"
-                        >Go</button>
-                    </div>
-                @endif
-
-                @if(count($this->massActionsOptions))
-                    <div class="flex items-center justify-center space-x-1">
-                        <label for="datatables_mass_actions">{{ __('With selected') }}:</label>
-                        <select wire:model="massActionOption" class="px-3 text-xs font-medium tracking-wider uppercase bg-white border border-green-400 space-x-2 rounded-md leading-4 focus:outline-none" id="datatables_mass_actions">
-                            <option value="">{{ __('Choose...') }}</option>
-                            @foreach($this->massActionsOptions as $group => $items)
-                                @if(!$group)
-                                    @foreach($items as $item)
-                                        <option value="{{$item['value']}}">{{$item['label']}}</option>
-                                    @endforeach
-                                @else
-                                    <optgroup label="{{$group}}">
-                                        @foreach($items as $item)
-                                            <option value="{{$item['value']}}">{{$item['label']}}</option>
-                                        @endforeach
-                                    </optgroup>
-                                @endif
-                            @endforeach
-                        </select>
-                        <button
-                            wire:click="massActionOptionHandler"
-                            class="flex items-center px-4 py-2 text-xs font-medium tracking-wider text-green-500 uppercase bg-white border border-green-400 rounded-md leading-4 hover:bg-green-200 focus:outline-none" type="submit" title="Submit"
-                        >Go</button>
-                    </div>
-                @endif
-
-                @if($exportable)
-                    <div x-data="{ init() {
-                        window.livewire.on('startDownload', link => window.open(link, '_blank'))
-                        } }" x-init="init">
-                        <button wire:click="export" class="flex items-center px-3 text-xs font-medium tracking-wider text-green-500 uppercase bg-white border border-green-400 space-x-2 rounded-md leading-4 hover:bg-green-200 focus:outline-none"><span>{{ __('Export') }}</span>
-                            <x-icons.excel class="m-2" /></button>
-                    </div>
-                @endif
-
-                @if($hideable === 'select')
-                    @include('datatables::hide-column-multiselect')
-                @endif
-
-                @foreach ($columnGroups as $name => $group)
-                    <button wire:click="toggleGroup('{{ $name }}')"
-                            class="px-3 py-2 text-xs font-medium tracking-wider text-green-500 uppercase bg-white border border-green-400 rounded-md leading-4 hover:bg-green-200 focus:outline-none">
-                        <span class="flex items-center h-5">{{ isset($this->groupLabels[$name]) ? __($this->groupLabels[$name]) : __('Toggle :group', ['group' => $name]) }}</span>
-                    </button>
-                @endforeach
-                @includeIf($buttonsSlot)
-            </div>
+<div class="container mx-auto pt-2">
+    @if (method_exists($this, 'tableTitle'))
+        <div class="{{ $titleClass ?? 'pb-1' }}">
+            {{ $this->tableTitle() }}
         </div>
+    @endif
 
-        @if($hideable === 'buttons')
+    @if ($beforeTableSlot && (method_exists($this, 'showBeforeTableSlot') ? $this->showBeforeTableSlot() : true))
+        @includeIf($beforeTableSlot)
+    @endif
+
+    <div @class([
+        'relative pb-8',
+        'flex flex-wrap' => $this->flexWrapTable ?? false
+    ])>
+        @if ($hideable)
+            @include('livewire.datatables.components.table-filters')
+        @endif
+
+        @if ($this->searchableColumns()->count())
+            @php($isMultiSort = isset($this->multisort) && $this->multisort === true && count($this->sort) >= 1)
+
+            <div @class([
+               'content-end py-6',
+               'flex justify-between items-center' => $isMultiSort
+            ])>
+                @if ($isMultiSort)
+                    <button
+                        wire:loading.class="opacity-50"
+                        wire:click="forgetSortSession"
+                        class="
+                            px-5 py-2 rounded-md bg-white text-xs leading-5 font-medium tracking-wider
+                            hover:bg-gray-50 focus:outline-none
+                        "
+                    >
+                        <div class="flex items-center text-sm leading-5 font-medium text-cool-gray-700">
+                            {{ 'Reset '. Str::plural('Column', count($this->sort)) .' Sorting' }}
+                        </div>
+                    </button>
+                @endif
+
+                @include('livewire.datatables.components.search-box')
+            </div>
+        @endif
+
+        @if ($this->activeFilters)
+            <span class="text-xl text-blue-400 uppercase">
+                @lang('Filter active')
+            </span>
+        @endif
+
+        @if ($this->activeFilters)
+            <button
+                wire:click="clearAllFilters"
+                class="
+                    flex items-center px-3 text-xs font-medium tracking-wider text-red-500 uppercase
+                    bg-white border border-red-400 space-x-2 rounded-md leading-4 hover:bg-red-200
+                    focus:outline-none
+                "
+            >
+                <span>{{ __('Reset') }}</span>
+                <x-icons.x-circle class="m-2"/>
+            </button>
+        @endif
+
+        @if (count($this->massActionsOptions))
+            <div class="flex items-center justify-center space-x-1">
+                <label for="datatables_mass_actions">{{ __('With selected') }}:</label>
+
+                <select
+                    wire:model.live="massActionOption"
+                    class="
+                        px-3 text-xs font-medium tracking-wider uppercase bg-white border border-green-400
+                        space-x-2 rounded-md leading-4 focus:outline-none
+                    "
+                    id="datatables_mass_actions"
+                >
+                    <option value="">{{ __('Choose...') }}</option>
+
+                    @foreach($this->massActionsOptions as $group => $items)
+                        @if (!$group)
+                            @foreach($items as $item)
+                                <option wire:key="mass-options-not-group-items-{{ $item }}" value="{{ $item['value'] }}">{{ $item['label'] }}</option>
+                            @endforeach
+                        @else
+                            <optgroup label="{{ $group }}">
+                                @foreach($items as $item)
+                                    <option wire:key="mass-options-group-items-{{ $item }}" value="{{ $item['value'] }}">{{ $item['label'] }}</option>
+                                @endforeach
+                            </optgroup>
+                        @endif
+                    @endforeach
+                </select>
+
+                <button
+                    wire:click="massActionOptionHandler"
+                    class="
+                        flex items-center px-4 py-2 text-xs font-medium tracking-wider text-green-500 uppercase
+                        bg-white border border-green-400 rounded-md leading-4 hover:bg-green-200 focus:outline-none
+                    "
+                    type="submit"
+                    title="Submit"
+                >
+                    Go
+                </button>
+            </div>
+        @endif
+
+        @if ($exportable)
+            <div
+                x-data="{
+                    init() {
+                        window.livewire.on('startDownload', link => window.open(link, '_blank'))
+                    }
+                }"
+            >
+                <button
+                    wire:click="export"
+                    class="
+                        flex items-center px-3 text-xs font-medium tracking-wider text-green-500
+                        uppercase bg-white border border-green-400 space-x-2 rounded-md leading-4
+                        hover:bg-green-200 focus:outline-none
+                    "
+                >
+                    <span>{{ __('Export') }}</span>
+                    <x-icons.excel class="m-2"/>
+                </button>
+            </div>
+        @endif
+
+        @if ($hideable === 'select')
+            @include('datatables::hide-column-multiselect')
+        @endif
+
+        @foreach ($columnGroups as $name => $group)
+            <button
+                wire:key="column-group-group-name-{{ $name }}"
+                wire:click="toggleGroup('{{ $name }}')"
+                class="
+                    px-3 py-2 text-xs font-medium tracking-wider text-green-500 uppercase bg-white
+                    border border-green-400 rounded-md leading-4 hover:bg-green-200 focus:outline-none
+                "
+            >
+                <span class="flex items-center h-5">
+                    {{ isset($this->groupLabels[$name]) ? __($this->groupLabels[$name]) : __('Toggle :group', ['group' => $name]) }}
+                </span>
+            </button>
+        @endforeach
+
+        @includeIf($buttonsSlot)
+
+        @if ($hideable === 'buttons')
             <div class="p-2 grid grid-cols-8 gap-2">
                 @foreach($this->columns as $index => $column)
                     @if ($column['hideable'])
-                        <button wire:click="toggle('{{ $index }}')" class="px-3 py-2 rounded text-white text-xs focus:outline-none
-                        {{ $column['hidden'] ? 'bg-blue-100 hover:bg-blue-300 text-blue-600' : 'bg-blue-500 hover:bg-blue-800' }}">
+                        <button
+                            wire:key="hideable-columns-{{ $index }}"
+                            wire:click="toggle('{{ $index }}')"
+                            @class([
+                                'px-3 py-2 rounded text-white text-xs focus:outline-none',
+                                'bg-blue-100 hover:bg-blue-300 text-blue-600' =>  $column['hidden'],
+                                'bg-blue-500 hover:bg-blue-800'               => !$column['hidden'],
+                            ])
+                        >
                             {{ $column['label'] }}
                         </button>
                     @endif
@@ -131,129 +169,174 @@
             </div>
         @endif
 
-        <div wire:loading.class="opacity-50" class="rounded-lg @unless($complex || $this->hidePagination) rounded-b-none @endunless shadow-lg bg-white max-w-screen overflow-x-scroll border-2 @if($this->activeFilters) border-blue-500 @else border-transparent @endif @if($complex) rounded-b-none border-b-0 @endif">
-            <div>
-                <div class="table min-w-full align-middle">
-                    @unless($this->hideHeader)
-                        <div class="table-row divide-x divide-gray-200">
-                            @foreach($this->columns as $index => $column)
-                                @if($hideable === 'inline')
-                                    @include('datatables::header-inline-hide', ['column' => $column, 'sort' => $sort])
-                                @elseif($column['type'] === 'checkbox')
-                                    @unless($column['hidden'])
-                                        <div class="flex justify-center table-cell w-32 h-12 px-6 py-4 overflow-hidden text-xs font-medium tracking-wider text-left text-gray-500 uppercase align-top border-b border-gray-200 bg-gray-50 leading-4 focus:outline-none">
-                                            <div class="px-3 py-1 rounded @if(count($selected)) bg-orange-400 @else bg-gray-200 @endif text-white text-center">
-                                                {{ count($selected) }}
-                                            </div>
-                                        </div>
-                                    @endunless
-                                @else
-                                    @include('datatables::header-no-hide', ['column' => $column, 'sort' => $sort])
-                                @endif
-                            @endforeach
-                        </div>
-                    @endunless
-                    <div class="table-row bg-blue-100 divide-x divide-blue-200">
-                        @foreach($this->columns as $index => $column)
-                            @if($column['hidden'])
-                                @if($hideable === 'inline')
-                                    <div class="table-cell w-5 overflow-hidden align-top bg-blue-100"></div>
-                                @endif
-                            @elseif($column['type'] === 'checkbox')
-                                @include('datatables::filters.checkbox')
-                            @elseif($column['type'] === 'label')
-                                <div class="table-cell overflow-hidden align-top">
-                                    {{ $column['label'] ?? '' }}
-                                </div>
-                            @else
-                                <div class="table-cell overflow-hidden align-top">
-                                    @isset($column['filterable'])
-                                        @if( is_iterable($column['filterable']) )
-                                            <div wire:key="{{ $index }}">
-                                                @include('datatables::filters.select', ['index' => $index, 'name' => $column['label'], 'options' => $column['filterable']])
-                                            </div>
+        <div
+            wire:loading.class="opacity-50"
+            @class([
+                'rounded-lg shadow-lg bg-white max-w-screen overflow-hidden',
+                'rounded-b-none'  => $complex || !$this->hidePagination,
+                'border-blue-500' => $this->activeFilters,
+                isset($this->tableSize) ? $this->tableSize : '',
+            ])
+        >
+            <div class="flex flex-col">
+                <div class="overflow-x-auto soft-scrollbar">
+                    <table class="min-w-full divide-y divide-gray-300">
+                        @unless($this->hideHeader)
+                            <thead class="bg-gray-50">
+                            <tr data-cy="data-table-header">
+                                @foreach($this->columns as $index => $column)
+                                    <th wire:key="header-column-{{ $index }}" scope="col" class="py-3 px-3 first:px-5 last:px-5 whitespace-nowrap">
+                                        @if ($hideable === 'inline')
+                                            @include('datatables::header-inline-hide', ['column' => $column, 'sort' => $sort, 'key' => "header-inline-hide-index-$index"])
+                                        @elseif($column['type'] === 'checkbox')
+                                            @unless($column['hidden'])
+                                                <div @class([
+                                                        'rounded text-white text-center',
+                                                        'bg-orange-400' =>  count($selected),
+                                                        'bg-gray-200'   => !count($selected),
+                                                    ])>
+                                                    {{ count($selected) }}
+                                                </div>
+                                            @endunless
                                         @else
-                                            <div wire:key="{{ $index }}">
-                                                @include('datatables::filters.' . ($column['filterView'] ?? $column['type']), ['index' => $index, 'name' => $column['label']])
-                                            </div>
+                                            @include('datatables::header-no-hide', ['column' => $column, 'sort' => $sort])
                                         @endif
-                                    @endisset
-                                </div>
-                            @endif
-                        @endforeach
-                    </div>
-                    @foreach($this->results as $row)
-                        <div class="table-row p-1 {{ $this->rowClasses($row, $loop) }}">
-                            @foreach($this->columns as $column)
-                                @if($column['hidden'])
-                                    @if($hideable === 'inline')
-                                        <div class="table-cell w-5 @unless($column['wrappable']) whitespace-nowrap truncate @endunless overflow-hidden align-top"></div>
+                                    </th>
+                                @endforeach
+                            </tr>
+                            </thead>
+                        @endunless
+
+                        <tbody class="divide-y divide-gray-200">
+                        <tr>
+                            @foreach($this->columns as $index => $column)
+                                @if ($column['hidden'])
+                                    @if ($hideable === 'inline')
+                                        <td wire:key="inline-column-{{ $index }}" class="w-5 overflow-hidden align-top bg-blue-100"></td>
                                     @endif
                                 @elseif($column['type'] === 'checkbox')
-                                    @include('datatables::checkbox', ['value' => $row->checkbox_attribute])
+                                    <td wire:key="checkbox-column-{{ $index }}">@include('datatables::filters.checkbox')</td>
                                 @elseif($column['type'] === 'label')
-                                    @include('datatables::label')
+                                    <td wire:key="label-column-{{ $index }}">
+                                        {{ $column['label'] ?? '' }}
+                                    </td>
                                 @else
-
-                                    <div class="table-cell px-6 py-2 @unless($column['wrappable']) whitespace-nowrap truncate @endunless @if($column['contentAlign'] === 'right') text-right @elseif($column['contentAlign'] === 'center') text-center @else text-left @endif {{ $this->cellClasses($row, $column) }}">
-                                        {!! $row->{$column['name']} !!}
-                                    </div>
+                                    <td>
+                                        @isset($column['filterable'])
+                                            @if ( is_iterable($column['filterable']) )
+                                                <div wire:key="column-filterable-iterable-index-{{ $index }}">
+                                                    @include('datatables::filters.select', ['index' => $index, 'name' => $column['label'], 'options' => $column['filterable']])
+                                                </div>
+                                            @else
+                                                <div wire:key="column-filterable-not-iterable-index-{{ $index }}">
+                                                    @include('datatables::filters.' . ($column['filterView'] ?? $column['type']), ['index' => $index, 'name' => $column['label']])
+                                                </div>
+                                            @endif
+                                        @endisset
+                                    </td>
                                 @endif
                             @endforeach
-                        </div>
-                    @endforeach
+                        </tr>
 
-                    @if ($this->hasSummaryRow())
-                        <div class="table-row p-1">
-                            @foreach($this->columns as $column)
-                                @unless($column['hidden'])
-                                    @if ($column['summary'])
-                                        <div class="table-cell px-6 py-2 @unless ($column['wrappable']) whitespace-nowrap truncate @endunless @if($column['contentAlign'] === 'right') text-right @elseif($column['contentAlign'] === 'center') text-center @else text-left @endif {{ $this->cellClasses($row, $column) }}">
-                                            {{ $this->summarize($column['name']) }}
-                                        </div>
-                                    @else
-                                        <div class="table-cell"></div>
-                                    @endif
-                                @endunless
-                            @endforeach
-                        </div>
-                    @endif
+                        @foreach($this->results as $row)
+                            <tr wire:key="results-row-{{ $row->id }}"
+                                @class([
+                                    'text-sm',
+                                    '!border-t-0' => $loop->first,
+                                    $this->rowClasses($row, $loop)
+                                ])>
+                                @foreach($this->columns as $column)
+                                    <td wire:key="results-column-{{ $column['name'] }}" @class([
+                                            'text-sm px-3 py-3 text-gray-500 first:px-5 last:px-5',
+                                            'truncate'    => !$column['wrappable'],
+                                            'text-right ' =>  $column['contentAlign'] === 'right',
+                                            'text-center' =>  $column['contentAlign'] === 'center',
+                                            $this->cellClasses($row, $column)
+                                        ])>
+                                        @if ($column['hidden'])
+                                            @if ($hideable === 'inline')
+                                                <span></span>
+                                            @endif
+                                        @elseif($column['type'] === 'checkbox')
+                                            @include('datatables::checkbox', ['value' => $row->checkbox_attribute])
+                                        @elseif($column['type'] === 'label')
+                                            @include('datatables::label')
+                                        @else
+                                            {!! $row->{$column['name']} !!}
+                                        @endif
+                                    </td>
+                                @endforeach
+                            </tr>
+                        @endforeach
+
+                        @if($this->results->count() === 0)
+                            <tr class="!border-t-0">
+                                <td class="p-4 text-gray-500" colspan="12">
+                                    No results found
+                                </td>
+                            </tr>
+                        @endif
+
+                        @if (
+                            $this->results->count()
+                            && isset($this->clhCustomColSum)
+                            && $this->clhCustomColSum
+                            && method_exists($this, 'getCellsCustomSum')
+                        )
+                            @php($sumPerColumn = $this->getCellsCustomSum($this->results->all()))
+
+                            <tr>
+                                <td>
+                                    @include("livewire.datatables.components.{$this->sumBladeFileName()}", [
+                                        'sumPerColumn'=> $sumPerColumn,
+                                        'totalRowName'=> $this->totalRowName(),
+                                    ])
+                                </td>
+                            </tr>
+                        @endif
+                        </tbody>
+                    </table>
                 </div>
             </div>
-            @if($this->results->isEmpty())
-                <p class="p-3 text-lg text-center">
-                    {{ __("There's Nothing to show at the moment") }}
-                </p>
-            @endif
         </div>
 
         @unless($this->hidePagination)
-            <div class="max-w-screen bg-white @unless($complex) rounded-b-lg @endunless border-4 border-t-0 border-b-0 @if($this->activeFilters) border-blue-500 @else border-transparent @endif">
-                <div class="items-center justify-between p-2 sm:flex">
-                    {{-- check if there is any data --}}
-                    @if(count($this->results))
-                        <div class="flex items-center my-2 sm:my-0">
-                            <select name="perPage" class="block w-full py-2 pl-3 pr-10 mt-1 text-base border-gray-300 form-select leading-6 focus:outline-none focus:shadow-outline-blue focus:border-blue-300 sm:text-sm sm:leading-5" wire:model.live="perPage">
+            <div class="w-full bg-white border-t rounded-b-lg shadow">
+                <div class="py-2 px-6 sm:flex items-center justify-between">
+                    <div class="flex items-center">
+                        <div class="hidden sm:block mr-4">
+                            <p class="text-sm text-gray-700">
+                                <span class="font-medium">{{ 'Showing' . ' ' . $this->results->firstItem() }}</span>
+                                <span class="font-medium">{{ 'to' .' ' . $this->results->lastItem() }}</span>
+                                <span
+                                    class="font-medium">{{ 'of' . ' ' . $this->results->total() . ' ' .  'results' }}</span>
+                            </p>
+                        </div>
+
+                        <div class="relative inline-block text-left">
+                            <select
+                                name="perPage"
+                                class="inline-flex justify-center pl-3 pr-10 w-full rounded-md border border-gray-300 shadow-sm py-2 bg-white text-sm font-medium text-gray-700 hover:bg-gray-50 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-offset-gray-100 focus:ring-indigo-500"
+                                wire:model.live="perPage"
+                            >
                                 @foreach(config('livewire-datatables.per_page_options', [ 10, 25, 50, 100 ]) as $per_page_option)
-                                    <option value="{{ $per_page_option }}">{{ $per_page_option }}</option>
+                                    <option wire:key="per-page-options-{{ $per_page_option }}" value="{{ $per_page_option }}">Show {{ $per_page_option }}</option>
                                 @endforeach
-                                <option value="99999999">{{__('All')}}</option>
                             </select>
                         </div>
+                    </div>
 
+                    @if (count($this->results))
                         <div class="my-4 sm:my-0">
                             <div class="lg:hidden">
-                                <span class="space-x-2">{{ $this->results->links('datatables::tailwind-simple-pagination') }}</span>
+                                <span class="space-x-2">
+                                    {{ $this->results->links('datatables::tailwind-simple-pagination') }}
+                                </span>
                             </div>
 
-                            <div class="justify-center hidden lg:flex">
+                            <div class="hidden lg:flex justify-center">
                                 <span>{{ $this->results->links('datatables::tailwind-pagination') }}</span>
                             </div>
-                        </div>
-
-                        <div class="flex justify-end text-gray-600">
-                            {{__('Results')}} {{ $this->results->firstItem() }} - {{ $this->results->lastItem() }} {{__('of')}}
-                            {{ $this->results->total() }}
                         </div>
                     @endif
                 </div>
@@ -261,13 +344,20 @@
         @endif
     </div>
 
-    @if($complex)
-        <div class="bg-gray-50 px-4 py-4 rounded-b-lg rounded-t-none shadow-lg border-2 @if($this->activeFilters) border-blue-500 @else border-transparent @endif @if($complex) border-t-0 @endif">
-            <livewire:complex-query :columns="$this->complexColumns" :persistKey="$this->persistKey" :savedQueries="method_exists($this, 'getSavedQueries') ? $this->getSavedQueries() : null" />
+    @if ($complex)
+        <div
+            class="bg-gray-50 px-4 py-4 rounded-b-lg rounded-t-none shadow-lg border-4 @if ($this->activeFilters) border-blue-500 @else border-transparent @endif @if ($complex) border-t-0 @endif">
+            <livewire:complex-query
+                :columns="$this->complexColumns"
+                :persist-key="$this->persistKey"
+                :saved-queries="method_exists($this, 'getSavedQueries') ? $this->getSavedQueries() : null"
+            />
         </div>
     @endif
 
-    @includeIf($afterTableSlot)
-
-    <span class="hidden text-sm text-left text-center text-right text-gray-900 bg-gray-100 bg-yellow-100 leading-5 bg-gray-50"></span>
+    @if ($afterTableSlot)
+        <div class="mt-8">
+            @include($afterTableSlot)
+        </div>
+    @endif
 </div>

--- a/resources/views/livewire/datatables/datatable.blade.php
+++ b/resources/views/livewire/datatables/datatable.blade.php
@@ -46,7 +46,7 @@
                 @if(count($this->massActionsOptions))
                     <div class="flex items-center justify-center space-x-1">
                         <label for="datatables_mass_actions">{{ __('With selected') }}:</label>
-                        <select wire:model="massActionOption" class="px-3 text-xs font-medium tracking-wider uppercase bg-white border border-green-400 space-x-2 rounded-md leading-4 focus:outline-none" id="datatables_mass_actions">
+                        <select wire:model.live="massActionOption" class="px-3 text-xs font-medium tracking-wider uppercase bg-white border border-green-400 space-x-2 rounded-md leading-4 focus:outline-none" id="datatables_mass_actions">
                             <option value="">{{ __('Choose...') }}</option>
                             @foreach($this->massActionsOptions as $group => $items)
                                 @if(!$group)
@@ -122,7 +122,7 @@
             <div class="p-2 grid grid-cols-8 gap-2">
                 @foreach($this->columns as $index => $column)
                     @if ($column['hideable'])
-                        <button wire:click.prefetch="toggle('{{ $index }}')" class="px-3 py-2 rounded text-white text-xs focus:outline-none
+                        <button wire:click="toggle('{{ $index }}')" class="px-3 py-2 rounded text-white text-xs focus:outline-none
                         {{ $column['hidden'] ? 'bg-blue-100 hover:bg-blue-300 text-blue-600' : 'bg-blue-500 hover:bg-blue-800' }}">
                             {{ $column['label'] }}
                         </button>
@@ -233,7 +233,7 @@
                     {{-- check if there is any data --}}
                     @if(count($this->results))
                         <div class="flex items-center my-2 sm:my-0">
-                            <select name="perPage" class="block w-full py-2 pl-3 pr-10 mt-1 text-base border-gray-300 form-select leading-6 focus:outline-none focus:shadow-outline-blue focus:border-blue-300 sm:text-sm sm:leading-5" wire:model="perPage">
+                            <select name="perPage" class="block w-full py-2 pl-3 pr-10 mt-1 text-base border-gray-300 form-select leading-6 focus:outline-none focus:shadow-outline-blue focus:border-blue-300 sm:text-sm sm:leading-5" wire:model.live="perPage">
                                 @foreach(config('livewire-datatables.per_page_options', [ 10, 25, 50, 100 ]) as $per_page_option)
                                     <option value="{{ $per_page_option }}">{{ $per_page_option }}</option>
                                 @endforeach

--- a/resources/views/livewire/datatables/header-inline-hide.blade.php
+++ b/resources/views/livewire/datatables/header-inline-hide.blade.php
@@ -1,4 +1,4 @@
-<div wire:click.prefetch="toggle('{{ $index }}')"
+<div wire:click="toggle('{{ $index }}')"
      class="@if($column['hidden']) relative table-cell h-12 w-3 bg-blue-100 hover:bg-blue-300 overflow-none align-top group @else hidden @endif"
      style="min-width:12px; max-width:12px"
      >
@@ -36,7 +36,7 @@
     @endif
 
     @if ($column['hideable'])
-        <button wire:click.prefetch="toggle('{{ $index }}')"
+        <button wire:click="toggle('{{ $index }}')"
                 class="absolute bottom-1 right-1 focus:outline-none">
             <x-icons.arrow-circle-left class="h-3 w-3 text-gray-300 hover:text-blue-400" />
         </button>

--- a/resources/views/livewire/datatables/header-inline-hide.blade.php
+++ b/resources/views/livewire/datatables/header-inline-hide.blade.php
@@ -1,32 +1,32 @@
 <div wire:click="toggle('{{ $index }}')"
      class="@if($column['hidden']) relative table-cell h-12 w-3 bg-blue-100 hover:bg-blue-300 overflow-none align-top group @else hidden @endif"
      style="min-width:12px; max-width:12px"
-     >
-     <button class="relative h-12 w-3 focus:outline-none">
+>
+    <button class="relative h-12 w-3 focus:outline-none">
          <span
              class="w-32 hidden group-hover:inline-block absolute z-10 top-0 left-0 ml-3 bg-blue-300 font-medium leading-4 text-xs text-left text-blue-700 tracking-wider transform uppercase focus:outline-none">
              {{ str_replace('_', ' ', $column['label']) }}
          </span>
-     </button>
-     <svg class="absolute text-blue-100 fill-current w-full inset-x-0 bottom-0"
-          viewBox="0 0 314.16 207.25">
-         <path stroke-miterlimit="10" d="M313.66 206.75H.5V1.49l157.65 204.9L313.66 1.49v205.26z" />
-     </svg>
+    </button>
+    <svg class="absolute text-blue-100 fill-current w-full inset-x-0 bottom-0"
+         viewBox="0 0 314.16 207.25">
+        <path stroke-miterlimit="10" d="M313.66 206.75H.5V1.49l157.65 204.9L313.66 1.49v205.26z" />
+    </svg>
 </div>
 <div class="@if($column['hidden']) hidden @else relative h-12 overflow-hidden align-top flex table-cell @endif" @include('datatables::style-width')>
 
     @if($column['sortable'])
-        <button wire:click="sort('{{ $index }}')"
+        <button wire:key="sortable-button-{{ $index }}" wire:click="sortColumn('{{ $index }}')"
                 class="w-full h-full px-6 py-3 border-b border-gray-200 bg-gray-50 text-xs leading-4 font-medium text-gray-500 uppercase tracking-wider flex justify-between items-center focus:outline-none">
-            <span class="inline flex-grow @if($column['headerAlign'] === 'right') text-right @elseif($column['headerAlign'] === 'center') text-center @endif"">{{ str_replace('_', ' ', $column['label']) }}</span>
+            <span class="inline flex-grow @if($column['headerAlign'] === 'right') text-right @elseif($column['headerAlign'] === 'center') text-center @endif">{{ str_replace('_', ' ', $column['label']) }}</span>
             <span class="inline text-xs text-blue-400">
-            @if($sort === $index)
-                @if($direction)
-                    <x-icons.chevron-up class="h-6 w-6 text-green-600 stroke-current" />
-                @else
-                    <x-icons.chevron-down class="h-6 w-6 text-green-600 stroke-current" />
+                @if($sort === $index)
+                    @if($direction)
+                        <x-icons.chevron-up class="h-6 w-6 text-green-600 stroke-current" />
+                    @else
+                        <x-icons.chevron-down class="h-6 w-6 text-green-600 stroke-current" />
+                    @endif
                 @endif
-            @endif
             </span>
         </button>
     @else

--- a/resources/views/livewire/datatables/header-no-hide.blade.php
+++ b/resources/views/livewire/datatables/header-no-hide.blade.php
@@ -1,44 +1,62 @@
 @unless($column['hidden'])
+    @php($label = str_replace('_', ' ', $column['label']))
+
     <div
-        @if (isset($column['tooltip']['text'])) title="{{ $column['tooltip']['text'] }}" @endif
-                                                class="relative table-cell h-12 overflow-hidden align-top" @include('datatables::style-width')>
-        @if(!$column['sortable'])
-            <div
-                class="w-full h-full px-6 py-3 border-b border-gray-200 bg-gray-50 text-left text-xs leading-4 font-medium text-gray-500 uppercase tracking-wider flex items-center focus:outline-none @if($column['headerAlign'] === 'right') justify-end @elseif($column['headerAlign'] === 'center') justify-center @endif">
-                <span class="inline ">{{ str_replace('_', ' ', $column['label']) }}</span>
+        class="relative bg-gray-50 overflow-hidden"
+        @isset($column['width']) style="width:{{ $column['width'] }}" @endisset
+        data-cy="data-table-header-cell"
+    >
+        @if (! $column['sortable'])
+            <div class="text-left text-xs font-medium text-gray-500 uppercase tracking-wider flex items-center focus:outline-none @if($column['headerAlign'] === 'right') justify-end @elseif($column['headerAlign'] === 'center') justify-center @endif">
+                <span class="inline text-center">
+                    {{ $label }}
+                </span>
             </div>
         @else
-            <button wire:click="sort('{{ $index }}')"
-                    class="w-full h-full px-6 py-3 border-b border-gray-200 bg-gray-50 text-left text-xs leading-4 font-medium text-gray-500 uppercase tracking-wider flex items-center focus:outline-none @if($column['headerAlign'] === 'right') justify-end @elseif($column['headerAlign'] === 'center') justify-center @endif">
-                <span class="inline ">{{ str_replace('_', ' ', $column['label']) }}</span>
-                <span class="inline flex text-xs text-blue-400">
-                    @if(! isset($this->multisort) || $this->multisort === false)
-                        @if(isset($sort[0]) && $this->getIndexFromValue($sort[0]) == $index && ($direction = $this->getColumnDirection($sort[0])))
-                            @if($direction === 'asc')
-                                <x-icons.chevron-up wire:loading.remove class="h-6 w-6 text-green-600 stroke-current"/>
-                            @endif
-                            @if($direction === 'desc')
-                                <x-icons.chevron-down wire:loading.remove
-                                                      class="h-6 w-6 text-green-600 stroke-current"/>
+            <button
+                wire:key="not-sortable-button-{{ $index }}"
+                data-cy="data-table-header-cell-button"
+                wire:click="sortColumn('{{ $index }}')"
+                @class([
+                    'text-left relative text-left text-xs font-medium uppercase',
+                    'tracking-wider flex items-center gap-x-2 focus:outline-none',
+                    'text-cyan-600'  => $isOrdering = method_exists($this, 'highlightOrdered') && $this->highlightOrdered($label),
+                    'text-gray-500'  => !$isOrdering,
+                    'justify-end'    => $column['headerAlign'] === 'right',
+                    'justify-center' => $column['headerAlign'] === 'center',
+                ])
+            >
+                <span class="whitespace-pre">{{ $label }}</span>
+
+                <span class="flex text-center text-xs">
+                    @if (! isset($this->multisort) || $this->multisort === false)
+                        @if (isset($sort[0]) && $this->getIndexFromValue($sort[0]) == $index && ($direction = $this->getColumnDirection($sort[0])))
+                            @if ($direction === 'asc')
+                                <x-icon class="h-5 w-5" name="sort-ascending" />
+                            @elseif ($direction === 'desc')
+                                <x-icon class="h-5 w-5" name="sort-descending" />
                             @endif
                         @endif
-                    @elseif($this->multisort === true)
+                    @else
                         @foreach($sort as $key => $value)
-                            @if($this->getIndexFromValue($value) == $index && ($direction = $this->getColumnDirection($value)))
-                                @if($direction === 'asc')
-                                    <x-icons.chevron-up wire:loading.remove
-                                                        class="h-6 w-6 text-green-600 stroke-current"/>
-                                    <div>{{$key + 1}}</div>
-                                @endif
-                                @if($direction === 'desc')
-                                    <x-icons.chevron-down wire:loading.remove
-                                                          class="h-6 w-6 text-green-600 stroke-current"/>
-                                    <div>{{$key + 1}}</div>
+                            @if ($this->getIndexFromValue($value) == $index && ($direction = $this->getColumnDirection($value)))
+                                @if ($direction === 'asc')
+                                    <x-icon class="h-5 w-5" name="sort-ascending" />
+
+                                    @if (count($this->sort) > 1)
+                                        <div>{{ $key + 1 }}</div>
+                                    @endif
+                                @elseif ($direction === 'desc')
+                                    <x-icon class="h-5 w-5" name="sort-descending" />
+
+                                    @if (count($this->sort) > 1)
+                                        <div>{{ $key + 1 }}</div>
+                                    @endif
                                 @endif
                             @endif
                         @endforeach
                     @endif
-            </span>
+                </span>
             </button>
         @endif
     </div>

--- a/src/Commands/MakeDatatableCommand.php
+++ b/src/Commands/MakeDatatableCommand.php
@@ -3,7 +3,7 @@
 namespace Mediconesystems\LivewireDatatables\Commands;
 
 use Illuminate\Support\Facades\File;
-use Livewire\Commands\FileManipulationCommand;
+use Livewire\Features\SupportConsoleCommands\Commands\FileManipulationCommand;
 use Livewire\LivewireComponentsFinder;
 
 class MakeDatatableCommand extends FileManipulationCommand

--- a/src/Http/Livewire/ComplexQuery.php
+++ b/src/Http/Livewire/ComplexQuery.php
@@ -64,12 +64,12 @@ class ComplexQuery extends Component
     {
         $this->validateRules();
 
-        $this->emit('complexQuery', count($this->rules[0]['content']) ? $this->rules : null);
+        $this->dispatch('complexQuery', count($this->rules[0]['content']) ? $this->rules : null);
     }
 
     public function saveQuery($name)
     {
-        $this->emitUp('saveQuery', $name, $this->rules);
+        $this->dispatch('saveQuery', $name, $this->rules);
     }
 
     public function loadRules($rules)
@@ -80,7 +80,7 @@ class ComplexQuery extends Component
 
     public function deleteRules($id)
     {
-        $this->emitUp('deleteQuery', $id);
+        $this->dispatch('deleteQuery', $id);
     }
 
     public function resetQuery()

--- a/src/Http/Livewire/LivewireDatatable.php
+++ b/src/Http/Livewire/LivewireDatatable.php
@@ -762,6 +762,10 @@ class LivewireDatatable extends Component
                 return Str::before($column['select'][0], ' AS ');
 
             case $column['select']:
+                if ($column['select'] instanceof Expression) {
+                    return Str::before($column['select']->getValue(DB::connection()->getQueryGrammar()), ' AS ');
+                }
+
                 return Str::before($column['select'], ' AS ');
 
              default:

--- a/src/Http/Livewire/LivewireDatatable.php
+++ b/src/Http/Livewire/LivewireDatatable.php
@@ -147,7 +147,7 @@ class LivewireDatatable extends Component
      * This events allows to control the options of the datatable from foreign livewire components
      * by using $emit.
      *
-     * @example $this->emit('applyToTable', ['perPage' => 25]); // in any other livewire component on the same page
+     * @example $this->dispatch('applyToTable', ['perPage' => 25]); // in any other livewire component on the same page
      */
     public function applyToTable($options)
     {
@@ -1319,6 +1319,7 @@ class LivewireDatatable extends Component
     public function complexQuery($rules)
     {
         $this->complexQuery = $rules;
+        $this->setPage(1);
     }
 
     public function addComplexQuery()
@@ -1330,8 +1331,6 @@ class LivewireDatatable extends Component
         $this->query->where(function ($query) {
             $this->processNested($this->complexQuery, $query);
         });
-
-        $this->setPage(1);
 
         return $this;
     }
@@ -1800,7 +1799,7 @@ class LivewireDatatable extends Component
 
     public function render()
     {
-        $this->emit('refreshDynamic');
+        $this->dispatch('refreshDynamic');
 
         if ($this->persistPerPage) {
             session()->put([$this->sessionStorageKey() . '_perpage' => $this->perPage]);

--- a/src/Http/Livewire/LivewireDatatable.php
+++ b/src/Http/Livewire/LivewireDatatable.php
@@ -1667,6 +1667,10 @@ class LivewireDatatable extends Component
                     $this->query->orderBy(DB::raw('FIELD(id,' . implode(',', $this->pinnedRecords) . ')'), 'DESC');
                 }
 
+                if ($columnName instanceof Expression) {
+                    $columnName = $columnName->getValue(DB::connection()->getQueryGrammar());
+                }
+
                 $this->query->orderByRaw($columnName . ' ' . ($direction = Str::after($sort, '|') == $index ? self::DEFAULT_DIRECTION : Str::after($sort, '|')));
             }
         }

--- a/src/Http/Livewire/LivewireDatatable.php
+++ b/src/Http/Livewire/LivewireDatatable.php
@@ -602,7 +602,7 @@ class LivewireDatatable extends Component
             })->keys()->first();
         }
 
-        $this->direction = $this->defaultSort() && $this->defaultSort()['direction'] === 'asc';
+        $this->direction = $default->isNotEmpty() && $default->first()['direction'] === 'asc';
 
         $this->sort = [$columnIndex . '|' . $direction];
         $this->getSessionStoredSort();

--- a/src/Http/Livewire/LivewireDatatable.php
+++ b/src/Http/Livewire/LivewireDatatable.php
@@ -152,7 +152,7 @@ class LivewireDatatable extends Component
     public function applyToTable($options)
     {
         if (isset($options['sort'])) {
-            $this->sort($options['sort'], $options['direction'] ?? null);
+            $this->sortColumn($options['sort'], $options['direction'] ?? null);
         }
 
         if (isset($options['hiddenColumns']) && is_array($options['hiddenColumns'])) {
@@ -829,7 +829,7 @@ class LivewireDatatable extends Component
      * @param string|null $direction needs to be 'asc' or 'desc'. set to null to toggle the current direction.
      * @return void
      */
-    public function sort($index, $direction = null)
+    public function sortColumn($index, $direction = null)
     {
         if (! in_array($direction, self::ORDER_BY_DIRECTION_STATES)) {
             throw new \Exception("Invalid direction $direction given in sort() method. Allowed values: asc, desc.");

--- a/src/Http/Livewire/LivewireDatatable.php
+++ b/src/Http/Livewire/LivewireDatatable.php
@@ -1671,9 +1671,9 @@ class LivewireDatatable extends Component
                     $this->query->orderBy(DB::raw('FIELD(id,' . implode(',', $this->pinnedRecords) . ')'), 'DESC');
                 }
 
-//                if ($columnName instanceof Expression) {
-//                    $columnName = $columnName->getValue(DB::connection()->getQueryGrammar());
-//                }
+                if ($columnName instanceof Expression) {
+                    $columnName = $columnName->getValue(DB::connection()->getQueryGrammar());
+                }
 
                 $this->query->orderByRaw($columnName . ' ' . ($direction = Str::after($sort, '|') == $index ? self::DEFAULT_DIRECTION : Str::after($sort, '|')));
             }

--- a/src/Http/Livewire/LivewireDatatable.php
+++ b/src/Http/Livewire/LivewireDatatable.php
@@ -294,8 +294,6 @@ class LivewireDatatable extends Component
         if ($this->persistSearch) {
             session()->put($this->sessionStorageKey() . '_search', $this->search);
         }
-
-        return parent::dehydrate(); // @phpstan-ignore-line
     }
 
     public function columns()

--- a/src/Http/Livewire/LivewireDatatable.php
+++ b/src/Http/Livewire/LivewireDatatable.php
@@ -356,6 +356,10 @@ class LivewireDatatable extends Component
     public function resolveAdditionalSelects($column)
     {
         $selects = collect($column->additionalSelects)->map(function ($select) use ($column) {
+            if ($select instanceof Expression) {
+                return $select;
+            }
+
             return Str::contains($select, '.')
                 ? $this->resolveColumnName($column, $select)
                 : $this->query->getModel()->getTable() . '.' . $select;
@@ -1667,9 +1671,9 @@ class LivewireDatatable extends Component
                     $this->query->orderBy(DB::raw('FIELD(id,' . implode(',', $this->pinnedRecords) . ')'), 'DESC');
                 }
 
-                if ($columnName instanceof Expression) {
-                    $columnName = $columnName->getValue(DB::connection()->getQueryGrammar());
-                }
+//                if ($columnName instanceof Expression) {
+//                    $columnName = $columnName->getValue(DB::connection()->getQueryGrammar());
+//                }
 
                 $this->query->orderByRaw($columnName . ' ' . ($direction = Str::after($sort, '|') == $index ? self::DEFAULT_DIRECTION : Str::after($sort, '|')));
             }

--- a/src/Http/Livewire/LivewireDatatable.php
+++ b/src/Http/Livewire/LivewireDatatable.php
@@ -1422,6 +1422,11 @@ class LivewireDatatable extends Component
                                         $query->orWhereRaw('LOWER(' . (Str::contains(mb_strtolower($column), 'concat') ? '' : $this->tablePrefix) . $col . ') like ?', '%' . mb_strtolower($search) . '%');
                                     }
                                 }, function ($query) use ($search, $column) {
+
+                                    if ($column instanceof  Expression) {
+                                        $column = $column->getValue(DB::connection()->getQueryGrammar());
+                                    }
+
                                     $query->orWhereRaw('LOWER(' . (Str::contains(mb_strtolower($column), 'concat') ? '' : $this->tablePrefix) . $column . ') like ?', '%' . mb_strtolower($search) . '%');
                                 });
                             }

--- a/src/Traits/WithCallbacks.php
+++ b/src/Traits/WithCallbacks.php
@@ -13,6 +13,6 @@ trait WithCallbacks
             ->where(Str::after($key, '.'), $rowId)
             ->update([$column => $value]);
 
-        $this->emit('fieldEdited', $rowId, $column);
+        $this->dispatch('fieldEdited', $rowId, $column);
     }
 }

--- a/tests/LivewireDatatableMultisortableQueryBuilderTest.php
+++ b/tests/LivewireDatatableMultisortableQueryBuilderTest.php
@@ -21,15 +21,15 @@ class LivewireDatatableMultisortableQueryBuilderTest extends TestCase
 
         $this->assertEquals('select "dummy_models"."id" as "id", "dummy_models"."subject" as "subject", "dummy_models"."category" as "category" from "dummy_models" order by `id` desc', $subject->getQuery()->toSql());
 
-        $subject->sort(0);
+        $subject->sortColumn(0);
 
         $this->assertEquals('select "dummy_models"."id" as "id", "dummy_models"."subject" as "subject", "dummy_models"."category" as "category" from "dummy_models" order by `id` asc', $subject->getQuery()->toSql());
 
-        $subject->sort(0);
+        $subject->sortColumn(0);
 
         $this->assertEquals('select "dummy_models"."id" as "id", "dummy_models"."subject" as "subject", "dummy_models"."category" as "category" from "dummy_models"', $subject->getQuery()->toSql());
 
-        $subject->sort(0);
+        $subject->sortColumn(0);
 
         $this->assertEquals('select "dummy_models"."id" as "id", "dummy_models"."subject" as "subject", "dummy_models"."category" as "category" from "dummy_models" order by `id` desc', $subject->getQuery()->toSql());
 
@@ -45,23 +45,23 @@ class LivewireDatatableMultisortableQueryBuilderTest extends TestCase
 
         $this->assertEquals('select "dummy_models"."id" as "id", "dummy_models"."subject" as "subject", "dummy_models"."category" as "category" from "dummy_models" order by `id` desc', $subject->getQuery()->toSql());
 
-        $subject->sort(1);
+        $subject->sortColumn(1);
 
         $this->assertEquals('select "dummy_models"."id" as "id", "dummy_models"."subject" as "subject", "dummy_models"."category" as "category" from "dummy_models" order by `id` desc, `subject` desc', $subject->getQuery()->toSql());
 
-        $subject->sort(1);
+        $subject->sortColumn(1);
 
         $this->assertEquals('select "dummy_models"."id" as "id", "dummy_models"."subject" as "subject", "dummy_models"."category" as "category" from "dummy_models" order by `id` desc, `subject` asc', $subject->getQuery()->toSql());
 
-        $subject->sort(1);
+        $subject->sortColumn(1);
 
         $this->assertEquals('select "dummy_models"."id" as "id", "dummy_models"."subject" as "subject", "dummy_models"."category" as "category" from "dummy_models" order by `id` desc', $subject->getQuery()->toSql());
 
-        $subject->sort(2);
+        $subject->sortColumn(2);
 
         $this->assertEquals('select "dummy_models"."id" as "id", "dummy_models"."subject" as "subject", "dummy_models"."category" as "category" from "dummy_models" order by `id` desc, `category` desc', $subject->getQuery()->toSql());
 
-        $subject->sort(1);
+        $subject->sortColumn(1);
 
         $this->assertEquals('select "dummy_models"."id" as "id", "dummy_models"."subject" as "subject", "dummy_models"."category" as "category" from "dummy_models" order by `id` desc, `category` desc, `subject` desc', $subject->getQuery()->toSql());
     }
@@ -77,15 +77,15 @@ class LivewireDatatableMultisortableQueryBuilderTest extends TestCase
 
         $this->assertEquals('select "dummy_models"."id" as "id", "dummy_has_one_models"."name" as "dummy_has_one.name", "dummy_has_one_models"."category" as "dummy_has_one.category" from "dummy_models" left join "dummy_has_one_models" on "dummy_has_one_models"."dummy_model_id" = "dummy_models"."id" order by `id` desc', $subject->getQuery()->toSql());
 
-        $subject->sort(1);
+        $subject->sortColumn(1);
         $subject->forgetComputed();
         $this->assertEquals('select "dummy_models"."id" as "id", "dummy_has_one_models"."name" as "dummy_has_one.name", "dummy_has_one_models"."category" as "dummy_has_one.category" from "dummy_models" left join "dummy_has_one_models" on "dummy_has_one_models"."dummy_model_id" = "dummy_models"."id" order by dummy_models.id desc, dummy_has_one_models.name desc', $subject->getQuery()->toSql());
 
-        $subject->sort(1);
+        $subject->sortColumn(1);
         $subject->forgetComputed();
         $this->assertEquals('select "dummy_models"."id" as "id", "dummy_has_one_models"."name" as "dummy_has_one.name", "dummy_has_one_models"."category" as "dummy_has_one.category" from "dummy_models" left join "dummy_has_one_models" on "dummy_has_one_models"."dummy_model_id" = "dummy_models"."id" order by dummy_models.id desc, dummy_has_one_models.name asc', $subject->getQuery()->toSql());
 
-        $subject->sort(2);
+        $subject->sortColumn(2);
         $subject->forgetComputed();
         $this->assertEquals('select "dummy_models"."id" as "id", "dummy_has_one_models"."name" as "dummy_has_one.name", "dummy_has_one_models"."category" as "dummy_has_one.category" from "dummy_models" left join "dummy_has_one_models" on "dummy_has_one_models"."dummy_model_id" = "dummy_models"."id" order by dummy_models.id desc, dummy_has_one_models.name asc, dummy_has_one_models.category desc', $subject->getQuery()->toSql());
     }
@@ -101,15 +101,15 @@ class LivewireDatatableMultisortableQueryBuilderTest extends TestCase
 
         $this->assertEquals('select (select group_concat(REPLACE(DISTINCT(dummy_has_many_models.name), \'\', \'\') , \', \') from "dummy_has_many_models" where "dummy_models"."id" = "dummy_has_many_models"."dummy_model_id") as `dummy_has_many.name`, "dummy_models"."id" as "id" from "dummy_models" order by `id` desc', $subject->getQuery()->toSql());
 
-        $subject->sort(1);
+        $subject->sortColumn(1);
 
         $this->assertEquals('select (select group_concat(REPLACE(DISTINCT(dummy_has_many_models.name), \'\', \'\') , \', \') from "dummy_has_many_models" where "dummy_models"."id" = "dummy_has_many_models"."dummy_model_id") as `dummy_has_many.name`, "dummy_models"."id" as "id" from "dummy_models" order by `id` desc, `dummy_has_many.name` desc', $subject->getQuery()->toSql());
 
-        $subject->sort(1);
+        $subject->sortColumn(1);
 
         $this->assertEquals('select (select group_concat(REPLACE(DISTINCT(dummy_has_many_models.name), \'\', \'\') , \', \') from "dummy_has_many_models" where "dummy_models"."id" = "dummy_has_many_models"."dummy_model_id") as `dummy_has_many.name`, "dummy_models"."id" as "id" from "dummy_models" order by `id` desc, `dummy_has_many.name` asc', $subject->getQuery()->toSql());
 
-        $subject->sort(0);
+        $subject->sortColumn(0);
 
         $this->assertEquals('select (select group_concat(REPLACE(DISTINCT(dummy_has_many_models.name), \'\', \'\') , \', \') from "dummy_has_many_models" where "dummy_models"."id" = "dummy_has_many_models"."dummy_model_id") as `dummy_has_many.name`, "dummy_models"."id" as "id" from "dummy_models" order by `dummy_has_many.name` asc, `id` asc', $subject->getQuery()->toSql());
     }
@@ -125,11 +125,11 @@ class LivewireDatatableMultisortableQueryBuilderTest extends TestCase
 
         $this->assertEquals('select (select COALESCE(avg(dummy_has_many_models.id),0) from "dummy_has_many_models" where "dummy_models"."id" = "dummy_has_many_models"."dummy_model_id") as `dummy_has_many.id:avg`, "dummy_models"."id" as "id" from "dummy_models" order by `id` desc', $subject->getQuery()->toSql());
 
-        $subject->sort(1);
+        $subject->sortColumn(1);
 
         $this->assertEquals('select (select COALESCE(avg(dummy_has_many_models.id),0) from "dummy_has_many_models" where "dummy_models"."id" = "dummy_has_many_models"."dummy_model_id") as `dummy_has_many.id:avg`, "dummy_models"."id" as "id" from "dummy_models" order by `id` desc, `dummy_has_many.id:avg` desc', $subject->getQuery()->toSql());
 
-        $subject->sort(1);
+        $subject->sortColumn(1);
 
         $this->assertEquals('select (select COALESCE(avg(dummy_has_many_models.id),0) from "dummy_has_many_models" where "dummy_models"."id" = "dummy_has_many_models"."dummy_model_id") as `dummy_has_many.id:avg`, "dummy_models"."id" as "id" from "dummy_models" order by `id` desc, `dummy_has_many.id:avg` asc', $subject->getQuery()->toSql());
     }
@@ -145,17 +145,17 @@ class LivewireDatatableMultisortableQueryBuilderTest extends TestCase
 
         $this->assertEquals('select "dummy_has_many_models"."id" as "id", "dummy_models"."name" as "dummy_model.name" from "dummy_has_many_models" left join "dummy_models" on "dummy_models"."id" = "dummy_has_many_models"."dummy_model_id" order by `id` desc', $subject->getQuery()->toSql());
 
-        $subject->sort(1);
+        $subject->sortColumn(1);
         $subject->forgetComputed();
 
         $this->assertEquals('select "dummy_has_many_models"."id" as "id", "dummy_models"."name" as "dummy_model.name" from "dummy_has_many_models" left join "dummy_models" on "dummy_models"."id" = "dummy_has_many_models"."dummy_model_id" order by dummy_has_many_models.id desc, dummy_models.name desc', $subject->getQuery()->toSql());
 
-        $subject->sort(1);
+        $subject->sortColumn(1);
         $subject->forgetComputed();
 
         $this->assertEquals('select "dummy_has_many_models"."id" as "id", "dummy_models"."name" as "dummy_model.name" from "dummy_has_many_models" left join "dummy_models" on "dummy_models"."id" = "dummy_has_many_models"."dummy_model_id" order by dummy_has_many_models.id desc, dummy_models.name asc', $subject->getQuery()->toSql());
 
-        $subject->sort(0);
+        $subject->sortColumn(0);
         $subject->forgetComputed();
 
         $this->assertEquals('select "dummy_has_many_models"."id" as "id", "dummy_models"."name" as "dummy_model.name" from "dummy_has_many_models" left join "dummy_models" on "dummy_models"."id" = "dummy_has_many_models"."dummy_model_id" order by dummy_models.name asc, dummy_has_many_models.id asc', $subject->getQuery()->toSql());
@@ -172,15 +172,15 @@ class LivewireDatatableMultisortableQueryBuilderTest extends TestCase
 
         $this->assertEquals('select (select group_concat(REPLACE(DISTINCT(dummy_belongs_to_many_models.name), \'\', \'\') , \', \') from "dummy_belongs_to_many_models" inner join "dummy_belongs_to_many_model_dummy_model" on "dummy_belongs_to_many_models"."id" = "dummy_belongs_to_many_model_dummy_model"."dummy_belongs_to_many_model_id" where "dummy_models"."id" = "dummy_belongs_to_many_model_dummy_model"."dummy_model_id" and "dummy_belongs_to_many_models"."deleted_at" is null) as `dummy_belongs_to_many.name`, "dummy_models"."id" as "id" from "dummy_models" order by `id` desc', $subject->getQuery()->toSql());
 
-        $subject->sort(1);
+        $subject->sortColumn(1);
 
         $this->assertEquals('select (select group_concat(REPLACE(DISTINCT(dummy_belongs_to_many_models.name), \'\', \'\') , \', \') from "dummy_belongs_to_many_models" inner join "dummy_belongs_to_many_model_dummy_model" on "dummy_belongs_to_many_models"."id" = "dummy_belongs_to_many_model_dummy_model"."dummy_belongs_to_many_model_id" where "dummy_models"."id" = "dummy_belongs_to_many_model_dummy_model"."dummy_model_id" and "dummy_belongs_to_many_models"."deleted_at" is null) as `dummy_belongs_to_many.name`, "dummy_models"."id" as "id" from "dummy_models" order by `id` desc, `dummy_belongs_to_many.name` desc', $subject->getQuery()->toSql());
 
-        $subject->sort(1);
+        $subject->sortColumn(1);
 
         $this->assertEquals('select (select group_concat(REPLACE(DISTINCT(dummy_belongs_to_many_models.name), \'\', \'\') , \', \') from "dummy_belongs_to_many_models" inner join "dummy_belongs_to_many_model_dummy_model" on "dummy_belongs_to_many_models"."id" = "dummy_belongs_to_many_model_dummy_model"."dummy_belongs_to_many_model_id" where "dummy_models"."id" = "dummy_belongs_to_many_model_dummy_model"."dummy_model_id" and "dummy_belongs_to_many_models"."deleted_at" is null) as `dummy_belongs_to_many.name`, "dummy_models"."id" as "id" from "dummy_models" order by `id` desc, `dummy_belongs_to_many.name` asc', $subject->getQuery()->toSql());
 
-        $subject->sort(0);
+        $subject->sortColumn(0);
 
         $this->assertEquals('select (select group_concat(REPLACE(DISTINCT(dummy_belongs_to_many_models.name), \'\', \'\') , \', \') from "dummy_belongs_to_many_models" inner join "dummy_belongs_to_many_model_dummy_model" on "dummy_belongs_to_many_models"."id" = "dummy_belongs_to_many_model_dummy_model"."dummy_belongs_to_many_model_id" where "dummy_models"."id" = "dummy_belongs_to_many_model_dummy_model"."dummy_model_id" and "dummy_belongs_to_many_models"."deleted_at" is null) as `dummy_belongs_to_many.name`, "dummy_models"."id" as "id" from "dummy_models" order by `dummy_belongs_to_many.name` asc, `id` asc', $subject->getQuery()->toSql());
     }

--- a/tests/LivewireDatatableQueryBuilderTest.php
+++ b/tests/LivewireDatatableQueryBuilderTest.php
@@ -20,11 +20,11 @@ class LivewireDatatableQueryBuilderTest extends TestCase
 
         $this->assertEquals('select "dummy_models"."id" as "id", "dummy_models"."subject" as "subject" from "dummy_models" order by `id` desc', $subject->getQuery()->toSql());
 
-        $subject->sort(1);
+        $subject->sortColumn(1);
 
         $this->assertEquals('select "dummy_models"."id" as "id", "dummy_models"."subject" as "subject" from "dummy_models" order by `subject` desc', $subject->getQuery()->toSql());
 
-        $subject->sort(1);
+        $subject->sortColumn(1);
 
         $this->assertEquals('select "dummy_models"."id" as "id", "dummy_models"."subject" as "subject" from "dummy_models" order by `subject` asc', $subject->getQuery()->toSql());
     }
@@ -39,12 +39,12 @@ class LivewireDatatableQueryBuilderTest extends TestCase
 
         $this->assertEquals('select "dummy_models"."id" as "id", "dummy_has_one_models"."name" as "dummy_has_one.name" from "dummy_models" left join "dummy_has_one_models" on "dummy_has_one_models"."dummy_model_id" = "dummy_models"."id" order by `id` desc', $subject->getQuery()->toSql());
 
-        $subject->sort(1);
+        $subject->sortColumn(1);
         $subject->forgetComputed();
 
         $this->assertEquals('select "dummy_models"."id" as "id", "dummy_has_one_models"."name" as "dummy_has_one.name" from "dummy_models" left join "dummy_has_one_models" on "dummy_has_one_models"."dummy_model_id" = "dummy_models"."id" order by dummy_has_one_models.name desc', $subject->getQuery()->toSql());
 
-        $subject->sort(1);
+        $subject->sortColumn(1);
         $subject->forgetComputed();
 
         $this->assertEquals('select "dummy_models"."id" as "id", "dummy_has_one_models"."name" as "dummy_has_one.name" from "dummy_models" left join "dummy_has_one_models" on "dummy_has_one_models"."dummy_model_id" = "dummy_models"."id" order by dummy_has_one_models.name asc', $subject->getQuery()->toSql());
@@ -73,11 +73,11 @@ class LivewireDatatableQueryBuilderTest extends TestCase
 
         $this->assertEquals('select (select group_concat(REPLACE(DISTINCT(dummy_has_many_models.name), \'\', \'\') , \', \') from "dummy_has_many_models" where "dummy_models"."id" = "dummy_has_many_models"."dummy_model_id") as `dummy_has_many.name`, "dummy_models"."id" as "id" from "dummy_models" order by `id` desc', $subject->getQuery()->toSql());
 
-        $subject->sort(1);
+        $subject->sortColumn(1);
 
         $this->assertEquals('select (select group_concat(REPLACE(DISTINCT(dummy_has_many_models.name), \'\', \'\') , \', \') from "dummy_has_many_models" where "dummy_models"."id" = "dummy_has_many_models"."dummy_model_id") as `dummy_has_many.name`, "dummy_models"."id" as "id" from "dummy_models" order by `dummy_has_many.name` desc', $subject->getQuery()->toSql());
 
-        $subject->sort(1);
+        $subject->sortColumn(1);
 
         $this->assertEquals('select (select group_concat(REPLACE(DISTINCT(dummy_has_many_models.name), \'\', \'\') , \', \') from "dummy_has_many_models" where "dummy_models"."id" = "dummy_has_many_models"."dummy_model_id") as `dummy_has_many.name`, "dummy_models"."id" as "id" from "dummy_models" order by `dummy_has_many.name` asc', $subject->getQuery()->toSql());
     }
@@ -92,11 +92,11 @@ class LivewireDatatableQueryBuilderTest extends TestCase
 
         $this->assertEquals('select (select COALESCE(avg(dummy_has_many_models.id),0) from "dummy_has_many_models" where "dummy_models"."id" = "dummy_has_many_models"."dummy_model_id") as `dummy_has_many.id:avg`, "dummy_models"."id" as "id" from "dummy_models" order by `id` desc', $subject->getQuery()->toSql());
 
-        $subject->sort(1);
+        $subject->sortColumn(1);
 
         $this->assertEquals('select (select COALESCE(avg(dummy_has_many_models.id),0) from "dummy_has_many_models" where "dummy_models"."id" = "dummy_has_many_models"."dummy_model_id") as `dummy_has_many.id:avg`, "dummy_models"."id" as "id" from "dummy_models" order by `dummy_has_many.id:avg` desc', $subject->getQuery()->toSql());
 
-        $subject->sort(1);
+        $subject->sortColumn(1);
 
         $this->assertEquals('select (select COALESCE(avg(dummy_has_many_models.id),0) from "dummy_has_many_models" where "dummy_models"."id" = "dummy_has_many_models"."dummy_model_id") as `dummy_has_many.id:avg`, "dummy_models"."id" as "id" from "dummy_models" order by `dummy_has_many.id:avg` asc', $subject->getQuery()->toSql());
     }
@@ -125,12 +125,12 @@ class LivewireDatatableQueryBuilderTest extends TestCase
 
         $this->assertEquals('select "dummy_has_many_models"."id" as "id", "dummy_models"."name" as "dummy_model.name" from "dummy_has_many_models" left join "dummy_models" on "dummy_models"."id" = "dummy_has_many_models"."dummy_model_id" order by `id` desc', $subject->getQuery()->toSql());
 
-        $subject->sort(1);
+        $subject->sortColumn(1);
         $subject->forgetComputed();
 
         $this->assertEquals('select "dummy_has_many_models"."id" as "id", "dummy_models"."name" as "dummy_model.name" from "dummy_has_many_models" left join "dummy_models" on "dummy_models"."id" = "dummy_has_many_models"."dummy_model_id" order by dummy_models.name desc', $subject->getQuery()->toSql());
 
-        $subject->sort(1);
+        $subject->sortColumn(1);
         $subject->forgetComputed();
 
         $this->assertEquals('select "dummy_has_many_models"."id" as "id", "dummy_models"."name" as "dummy_model.name" from "dummy_has_many_models" left join "dummy_models" on "dummy_models"."id" = "dummy_has_many_models"."dummy_model_id" order by dummy_models.name asc', $subject->getQuery()->toSql());
@@ -177,11 +177,11 @@ class LivewireDatatableQueryBuilderTest extends TestCase
 
         $this->assertEquals('select (select group_concat(REPLACE(DISTINCT(dummy_belongs_to_many_models.name), \'\', \'\') , \', \') from "dummy_belongs_to_many_models" inner join "dummy_belongs_to_many_model_dummy_model" on "dummy_belongs_to_many_models"."id" = "dummy_belongs_to_many_model_dummy_model"."dummy_belongs_to_many_model_id" where "dummy_models"."id" = "dummy_belongs_to_many_model_dummy_model"."dummy_model_id" and "dummy_belongs_to_many_models"."deleted_at" is null) as `dummy_belongs_to_many.name`, "dummy_models"."id" as "id" from "dummy_models" order by `id` desc', $subject->getQuery()->toSql());
 
-        $subject->sort(1);
+        $subject->sortColumn(1);
 
         $this->assertEquals('select (select group_concat(REPLACE(DISTINCT(dummy_belongs_to_many_models.name), \'\', \'\') , \', \') from "dummy_belongs_to_many_models" inner join "dummy_belongs_to_many_model_dummy_model" on "dummy_belongs_to_many_models"."id" = "dummy_belongs_to_many_model_dummy_model"."dummy_belongs_to_many_model_id" where "dummy_models"."id" = "dummy_belongs_to_many_model_dummy_model"."dummy_model_id" and "dummy_belongs_to_many_models"."deleted_at" is null) as `dummy_belongs_to_many.name`, "dummy_models"."id" as "id" from "dummy_models" order by `dummy_belongs_to_many.name` desc', $subject->getQuery()->toSql());
 
-        $subject->sort(1);
+        $subject->sortColumn(1);
 
         $this->assertEquals('select (select group_concat(REPLACE(DISTINCT(dummy_belongs_to_many_models.name), \'\', \'\') , \', \') from "dummy_belongs_to_many_models" inner join "dummy_belongs_to_many_model_dummy_model" on "dummy_belongs_to_many_models"."id" = "dummy_belongs_to_many_model_dummy_model"."dummy_belongs_to_many_model_id" where "dummy_models"."id" = "dummy_belongs_to_many_model_dummy_model"."dummy_model_id" and "dummy_belongs_to_many_models"."deleted_at" is null) as `dummy_belongs_to_many.name`, "dummy_models"."id" as "id" from "dummy_models" order by `dummy_belongs_to_many.name` asc', $subject->getQuery()->toSql());
     }


### PR DESCRIPTION
To update to laravel 10, we would need to update the base livewire datatables package dependencies.

This PR updates the composer json dependencies and adjusts the code to the new update.

We have added multisort functionality that does not exists with the package, that's why we use this forked repo.

We will need to merge this PR after we update to Laravel 10.